### PR TITLE
Don't add empty strings to the cookbook dependency list

### DIFF
--- a/lib/spiceweasel/cookbook_list.rb
+++ b/lib/spiceweasel/cookbook_list.rb
@@ -67,13 +67,12 @@ class Spiceweasel::CookbookList
     deps.each do |dependency|
       STDOUT.puts "DEBUG: cookbook #{cookbook} metadata dependency: #{dependency}" if DEBUG
       line = dependency.split()
-      cbdep = ''
       if line[1] =~ /^"/ #ignore variables and versions
         cbdep = line[1].gsub(/"/,'')
         cbdep.gsub!(/\,/,'') if cbdep.end_with?(',')
+        STDOUT.puts "DEBUG: cookbook #{cookbook} metadata depends: #{cbdep}" if DEBUG
+        @dependencies << cbdep
       end
-      STDOUT.puts "DEBUG: cookbook #{cookbook} metadata depends: #{cbdep}" if DEBUG
-      @dependencies << cbdep
     end
     return @cookbook
   end


### PR DESCRIPTION
The nginx cookbook uses single quotes for its metadata.rb dependencies and that causes spiceweasel to append an empty string to the list of cookbook dependencies, which can never be validated.
