### PR TITLE
YAML wildcards should be quoted

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ data bags:
   - bob
   - chuck
 - data:
-  - *
+  - "*"
 - passwords:
   - secret secret_key
   - mysql
@@ -225,7 +225,7 @@ knife role from file webserver.rb
 
 Data Bags
 ---------
-The `data bags` section of the manifest currently creates the data bags listed with `knife data bag create FOO` where `FOO` is the name of the data bag. Individual items may be added to the data bag as part of a JSON or YAML sequence, the assumption is made that they `.json` files and in the proper `data_bags/FOO` directory. You may also pass a wildcard as an entry to load all matching data bags (ie. `*`). Encrypted data bags are supported by listing `secret filename` as the first item (where `filename` is the secret key to be used). Validation is done to ensure the JSON is properly formatted, the id matches and any secret keys are in the correct locations. Assuming the presence of `dataA.json` and `dataB.json` in the `data_bags/data` directory, the YAML snippet
+The `data bags` section of the manifest currently creates the data bags listed with `knife data bag create FOO` where `FOO` is the name of the data bag. Individual items may be added to the data bag as part of a JSON or YAML sequence, the assumption is made that they `.json` files and in the proper `data_bags/FOO` directory. You may also pass a wildcard as an entry to load all matching data bags (ie. `"*"`). Encrypted data bags are supported by listing `secret filename` as the first item (where `filename` is the secret key to be used). Validation is done to ensure the JSON is properly formatted, the id matches and any secret keys are in the correct locations. Assuming the presence of `dataA.json` and `dataB.json` in the `data_bags/data` directory, the YAML snippet
 
 ``` yaml
 data bags:
@@ -234,7 +234,7 @@ data bags:
   - bob
   - chuck
 - data:
-  - *
+  - "*"
 - passwords:
   - secret secret_key
   - mysql

--- a/bin/spiceweasel
+++ b/bin/spiceweasel
@@ -66,9 +66,13 @@ else
       STDERR.puts "ERROR: Unknown file type, please use a file ending with either '.json' or '.yml'."
       exit(-1)
     end
+  rescue Psych::SyntaxError => e
+    STDERR.puts e.message
+    STDERR.puts "ERROR: Parsing error in #{file}."
+    exit(-1)
   rescue JSON::ParserError => e
     STDERR.puts e.message
-    STDERR.puts "ERROR: Parsing error in the infrastructure file provided."
+    STDERR.puts "ERROR: Parsing error in #{file}."
     exit(-1)
   rescue Exception
     STDERR.puts "ERROR: No infrastructure .json or .yml file provided."

--- a/example.yml
+++ b/example.yml
@@ -18,7 +18,7 @@ data bags:
   - bob
   - chuck
 - data:
-  - *
+  - "*"
 - passwords:
   - secret secret_key
   - mysql


### PR DESCRIPTION
- Quote the "*" wildcard used in the examples and README.
- Rescue the YAML exception.
