### PR TITLE
Add {{n}} token can be used to get the iteration number for each node.

### DIFF
--- a/lib/spiceweasel/node_list.rb
+++ b/lib/spiceweasel/node_list.rb
@@ -46,8 +46,8 @@ class Spiceweasel::NodeList
           end
           @delete += "knife node#{options['knife_options']} list | xargs knife #{provider[0]} server delete -y\n"
         else #node bootstrap support
-          nname.split.each do |server|
-            @create += "knife bootstrap#{options['knife_options']} #{server} #{noptions}"
+          nname.split.each_with_index do |server, i|
+            @create += "knife bootstrap#{options['knife_options']} #{server} #{noptions}".gsub(/{{n}}/, (i + 1).to_s)
             if run_list.length > 0
               @create += " -r '#{run_list}'\n"
             end


### PR DESCRIPTION
I had a use case where the node's name was being used to update DNS records at the end of a provisioning/chef run. Rather than repeating 3+ `- ec2 1:` entries, it would be nice if we had access to the iteration value when generating the knife commands.

Here's an example:

``` ruby
nodes:
- ec2 3:
  - role[coolness]
  - --node-name cool{{n}}.example.com --flavor m1.medium
- rackspace 1:
  - role[hotness]
  - --node-name hot{{n}}.example.com
```

``` bash
$ spiceweasel --novalidation example.yml
knife ec2 server create --node-name cool1.example.com --flavor m1.medium -r 'role[coolness]'
knife ec2 server create --node-name cool2.example.com --flavor m1.medium -r 'role[coolness]'
knife ec2 server create --node-name cool3.example.com --flavor m1.medium -r 'role[coolness]'
knife rackspace server create --node-name hot1.example.com -r 'role[hotness]'
```

The `--parallel` flag is also supported:

``` bash
$ spiceweasel --novalidation --parallel example.yml
seq 3 | parallel -j 0 -v "knife ec2 server create --node-name cool{}.example.com --flavor m1.medium -r 'role[coolness]'"
seq 1 | parallel -j 0 -v "knife rackspace server create --node-name hot{}.example.com -r 'role[hotness]'"
```

Thanks again Matt for Spiceweasel!
