### PR TITLE
Allow `depends "foo"` & `depends 'foo'` quoting styles in metadata.rb.

### DIFF
--- a/lib/spiceweasel/cookbook_list.rb
+++ b/lib/spiceweasel/cookbook_list.rb
@@ -68,8 +68,8 @@ class Spiceweasel::CookbookList
       STDOUT.puts "DEBUG: cookbook #{cookbook} metadata dependency: #{dependency}" if DEBUG
       line = dependency.split()
       cbdep = ''
-      if line[1] =~ /^"/ #ignore variables and versions
-        cbdep = line[1].gsub(/"/,'')
+      if line[1] =~ /^["']/ #ignore variables and versions
+        cbdep = line[1].gsub(/["']/,'')
         cbdep.gsub!(/\,/,'') if cbdep.end_with?(',')
       end
       STDOUT.puts "DEBUG: cookbook #{cookbook} metadata depends: #{cbdep}" if DEBUG


### PR DESCRIPTION
I found this when running `spiceweasel --extractlocal` on a repo containing a modern **nginx** cookbook. It's [metadata.rb](https://github.com/opscode-cookbooks/nginx/blob/master/metadata.rb) had the following:

``` ruby
depends 'ohai', '~> 1.0.2'
```

While this patch fixes this particular issue, we should also be able to support depends using other Ruby quoting styles and constructs:

``` ruby
depends %{foo}

%w{foo bar}.each do |cookbook|
  depends cookbook
end

# etc
```

Normally this would mean loading in metadata.rb to eval it and grab the parsed metadata, however the Chef gem is not a direct dependency of Spiceweasel (at the moment). Anyway, food for thought :)

Thanks again Matt!
