### PR TITLE
Remove the already initialized constant error

### DIFF
--- a/bin/spiceweasel
+++ b/bin/spiceweasel
@@ -30,13 +30,13 @@ begin
   ARGV << "-h" if ARGV.empty?
   cli = Spiceweasel::CLI.new
   cli.parse_options
-  DEBUG = cli.config[:debug]
-  PARALLEL = cli.config[:parallel]
-  SITEINSTALL = cli.config[:siteinstall]
-  NOVALIDATION = cli.config[:novalidation]
-  EXTRACTLOCAL = cli.config[:extractlocal]
-  EXTRACTYAML = cli.config[:extractyaml]
-  EXTRACTJSON = cli.config[:extractjson]
+  Spiceweasel::DEBUG = cli.config[:debug]
+  Spiceweasel::PARALLEL = cli.config[:parallel]
+  Spiceweasel::SITEINSTALL = cli.config[:siteinstall]
+  Spiceweasel::NOVALIDATION = cli.config[:novalidation]
+  Spiceweasel::EXTRACTLOCAL = cli.config[:extractlocal]
+  Spiceweasel::EXTRACTYAML = cli.config[:extractyaml]
+  Spiceweasel::EXTRACTJSON = cli.config[:extractjson]
 rescue OptionParser::InvalidOption => e
   STDERR.puts e.message
   puts cli.opt_parser.to_s
@@ -51,13 +51,13 @@ if cli.config[:serverurl]
   options['knife_options'] += " --server-url " + cli.config[:serverurl]
 end
 
-if EXTRACTLOCAL || EXTRACTJSON || EXTRACTYAML
+if Spiceweasel::EXTRACTLOCAL || Spiceweasel::EXTRACTJSON || Spiceweasel::EXTRACTYAML
   input = Spiceweasel::DirectoryExtractor.parse_objects
-  STDOUT.puts "DEBUG: extract input: #{input}" if DEBUG
+  STDOUT.puts "DEBUG: extract input: #{input}" if Spiceweasel::DEBUG
 else
   begin
     file = ARGV.last
-    STDOUT.puts "DEBUG: file: #{file}" if DEBUG
+    STDOUT.puts "DEBUG: file: #{file}" if Spiceweasel::DEBUG
     if (file.end_with?(".yml"))
       input = YAML.load_file ARGV.last
     elsif (file.end_with?(".json"))
@@ -75,7 +75,7 @@ else
     puts cli.opt_parser.to_s
     exit(-1)
   end
-  STDOUT.puts "DEBUG: file input: #{input}" if DEBUG
+  STDOUT.puts "DEBUG: file input: #{input}" if Spiceweasel::DEBUG
 end
 
 create = String.new()
@@ -107,9 +107,9 @@ elsif cli.config[:rebuild]
   puts delete unless delete.empty?
   puts create unless create.empty?
 else
-  if EXTRACTJSON
+  if Spiceweasel::EXTRACTJSON
     puts JSON.pretty_generate(input)
-  elsif EXTRACTYAML
+  elsif Spiceweasel::EXTRACTYAML
     puts input.to_yaml
   else
     puts create unless create.empty?

--- a/lib/spiceweasel/cookbook_list.rb
+++ b/lib/spiceweasel/cookbook_list.rb
@@ -29,12 +29,12 @@ class Spiceweasel::CookbookList
           version = cookbook[cb][0].to_s || ""
           args = cookbook[cb][1] || ""
         end
-        STDOUT.puts "DEBUG: cookbook: #{cb} #{version}" if DEBUG
+        STDOUT.puts "DEBUG: cookbook: #{cb} #{version}" if Spiceweasel::DEBUG
         if File.directory?("cookbooks")
           if File.directory?("cookbooks/#{cb}")
-            validateMetadata(cb,version) unless NOVALIDATION
+            validateMetadata(cb,version) unless Spiceweasel::NOVALIDATION
           else
-            if SITEINSTALL #use knife cookbook site install
+            if Spiceweasel::SITEINSTALL #use knife cookbook site install
               @create += "knife cookbook#{options['knife_options']} site install #{cb} #{version} #{args}\n"
             else #use knife cookbook site download, untar and then remove the tarball
               @create += "knife cookbook#{options['knife_options']} site download #{cb} #{version} --file cookbooks/#{cb}.tgz #{args}\n"
@@ -43,14 +43,14 @@ class Spiceweasel::CookbookList
             end
           end
         else
-          STDERR.puts "'cookbooks' directory not found, unable to validate, download and load cookbooks" unless NOVALIDATION
+          STDERR.puts "'cookbooks' directory not found, unable to validate, download and load cookbooks" unless Spiceweasel::NOVALIDATION
         end
         @create += "knife cookbook#{options['knife_options']} upload #{cb}\n"
         @delete += "knife cookbook#{options['knife_options']} delete #{cb} #{version} -a -y\n"
 
         @cookbook_list[cb] = version
       end
-      validateDependencies() unless NOVALIDATION
+      validateDependencies() unless Spiceweasel::NOVALIDATION
     end
   end
 
@@ -58,21 +58,21 @@ class Spiceweasel::CookbookList
   def validateMetadata(cookbook,version)
     #check metadata.rb for requested version
     metadata = File.open("cookbooks/#{cookbook}/metadata.rb").grep(/^version/)[0].split()[1].gsub(/"/,'').to_s
-    STDOUT.puts "DEBUG: cookbook metadata version: #{metadata}" if DEBUG
+    STDOUT.puts "DEBUG: cookbook metadata version: #{metadata}" if Spiceweasel::DEBUG
     if version and (metadata != version)
       STDERR.puts "ERROR: Invalid version '#{version}' of '#{cookbook}' requested, '#{metadata}' is already in the cookbooks directory."
       exit(-1)
     end
     deps = File.open("cookbooks/#{cookbook}/metadata.rb").grep(/^depends/)
     deps.each do |dependency|
-      STDOUT.puts "DEBUG: cookbook #{cookbook} metadata dependency: #{dependency}" if DEBUG
+      STDOUT.puts "DEBUG: cookbook #{cookbook} metadata dependency: #{dependency}" if Spiceweasel::DEBUG
       line = dependency.split()
       cbdep = ''
       if line[1] =~ /^"/ #ignore variables and versions
         cbdep = line[1].gsub(/"/,'')
         cbdep.gsub!(/\,/,'') if cbdep.end_with?(',')
       end
-      STDOUT.puts "DEBUG: cookbook #{cookbook} metadata depends: #{cbdep}" if DEBUG
+      STDOUT.puts "DEBUG: cookbook #{cookbook} metadata depends: #{cbdep}" if Spiceweasel::DEBUG
       @dependencies << cbdep
     end
     return @cookbook
@@ -80,7 +80,7 @@ class Spiceweasel::CookbookList
 
   #compare the list of cookbook deps with those specified
   def validateDependencies()
-    STDOUT.puts "DEBUG: cookbook validateDependencies: '#{@dependencies}'" if DEBUG
+    STDOUT.puts "DEBUG: cookbook validateDependencies: '#{@dependencies}'" if Spiceweasel::DEBUG
     @dependencies.each do |dep|
       if !member?(dep)
         STDERR.puts "ERROR: Cookbook dependency '#{dep}' is missing from the list of cookbooks in the manifest."

--- a/lib/spiceweasel/data_bag_list.rb
+++ b/lib/spiceweasel/data_bag_list.rb
@@ -23,23 +23,23 @@ class Spiceweasel::DataBagList
     @create = @delete = ''
     if data_bags
       if !File.directory?("data_bags")
-        STDERR.puts "ERROR: 'data_bags' directory not found, unable to validate or load data bag items" unless NOVALIDATION
+        STDERR.puts "ERROR: 'data_bags' directory not found, unable to validate or load data bag items" unless Spiceweasel::NOVALIDATION
       end
       data_bags.each do |data_bag|
         db = data_bag.keys[0]
-        STDOUT.puts "DEBUG: data bag: #{db}" if DEBUG
+        STDOUT.puts "DEBUG: data bag: #{db}" if Spiceweasel::DEBUG
         if !File.directory?("data_bags/#{db}")
-          STDERR.puts "ERROR: 'data_bags/#{db}' directory not found, unable to validate or load data bag items" unless NOVALIDATION
+          STDERR.puts "ERROR: 'data_bags/#{db}' directory not found, unable to validate or load data bag items" unless Spiceweasel::NOVALIDATION
         end
         @create += "knife data bag#{options['knife_options']} create #{db}\n"
         @delete += "knife data bag#{options['knife_options']} delete #{db} -y\n"
         items = data_bag[db] || []
         secret = nil
         while item = items.shift
-          STDOUT.puts "DEBUG: data bag #{db} item: #{item}" if DEBUG
+          STDOUT.puts "DEBUG: data bag #{db} item: #{item}" if Spiceweasel::DEBUG
           if item.start_with?("secret")
             secret = item.split()[1]
-            if !File.exists?(secret) and !NOVALIDATION
+            if !File.exists?(secret) and !Spiceweasel::NOVALIDATION
               STDERR.puts "ERROR: secret key #{secret} not found, unable to load encrypted data bags for data bag #{db}."
               exit(-1)
             end
@@ -48,10 +48,10 @@ class Spiceweasel::DataBagList
           if item =~ /\*/ #wildcard support, will fail if directory not present
             files = Dir.glob("data_bags/#{db}/#{item}.json")
             items += files.collect {|x| x[x.rindex('/')+1..-6]}
-            STDOUT.puts "DEBUG: found items '#{items}' for data bag: #{db}" if DEBUG
+            STDOUT.puts "DEBUG: found items '#{items}' for data bag: #{db}" if Spiceweasel::DEBUG
             next
           end
-          validateItem(db, item) unless NOVALIDATION
+          validateItem(db, item) unless Spiceweasel::NOVALIDATION
           if secret
             @create += "knife data bag#{options['knife_options']} from file #{db} #{item}.json --secret-file #{secret}\n"
           else

--- a/lib/spiceweasel/directory_extractor.rb
+++ b/lib/spiceweasel/directory_extractor.rb
@@ -25,13 +25,13 @@ class Spiceweasel::DirectoryExtractor
     cookbooks = []
     Dir.glob("cookbooks/*").each do |cookbook_full_path|
       cookbook = cookbook_full_path.split('/').last
-      STDOUT.puts "DEBUG: dir_ext: cookbook: '#{cookbook}'" if DEBUG
+      STDOUT.puts "DEBUG: dir_ext: cookbook: '#{cookbook}'" if Spiceweasel::DEBUG
       cookbook_data = Spiceweasel::CookbookData.new(cookbook)
       if cookbook_data.is_readable?
         cookbooks << cookbook_data.read
       end
     end
-    STDOUT.puts "DEBUG: dir_ext: cookbooks: '#{cookbooks}'" if DEBUG
+    STDOUT.puts "DEBUG: dir_ext: cookbooks: '#{cookbooks}'" if Spiceweasel::DEBUG
     cookbooks = self.order_cookbooks_by_dependency(cookbooks)
     objects["cookbooks"] = cookbooks unless cookbooks.empty?
 
@@ -39,7 +39,7 @@ class Spiceweasel::DirectoryExtractor
     roles = []
     Dir.glob("roles/*.{rb,json}").each do |role_full_path|
       role = self.grab_name_from_path(role_full_path)
-      STDOUT.puts "DEBUG: dir_ext: role: '#{role}'" if DEBUG
+      STDOUT.puts "DEBUG: dir_ext: role: '#{role}'" if Spiceweasel::DEBUG
       roles << {role => nil}
     end
     objects["roles"] = roles unless roles.nil?
@@ -47,7 +47,7 @@ class Spiceweasel::DirectoryExtractor
     environments = []
     Dir.glob("environments/*.{rb,json}").each do |environment_full_path|
       environment = self.grab_name_from_path(environment_full_path)
-      STDOUT.puts "DEBUG: dir_ext: environment: '#{environment}'" if DEBUG
+      STDOUT.puts "DEBUG: dir_ext: environment: '#{environment}'" if Spiceweasel::DEBUG
       environments << {environment => nil}
     end
     objects["environments"] = environments unless environments.empty?
@@ -55,10 +55,10 @@ class Spiceweasel::DirectoryExtractor
     data_bags = []
     Dir.glob("data_bags/*").each do |data_bag_full_path|
       data_bag = data_bag_full_path.split('/').last
-      STDOUT.puts "DEBUG: dir_ext: data_bag: '#{data_bag}'" if DEBUG
+      STDOUT.puts "DEBUG: dir_ext: data_bag: '#{data_bag}'" if Spiceweasel::DEBUG
       data_bag_items = []
       Dir.glob("#{data_bag_full_path}/*.{rb,json}").each do |data_bag_item_full_path|
-        STDOUT.puts "DEBUG: dir_ext: data_bag: '#{data_bag}':'#{data_bag_item_full_path}'" if DEBUG
+        STDOUT.puts "DEBUG: dir_ext: data_bag: '#{data_bag}':'#{data_bag_item_full_path}'" if Spiceweasel::DEBUG
         data_bag_items << self.grab_name_from_path(data_bag_item_full_path)
       end if File.directory?(data_bag_full_path)
       data_bags << {data_bag => data_bag_items} unless data_bag_items.empty?
@@ -102,12 +102,12 @@ class Spiceweasel::DirectoryExtractor
         unsorted_cookbooks.push(cookbook)
         scount = scount + 1
       end
-      STDOUT.puts "DEBUG: dir_ext: sorted_cookbooks: '#{sorted_cookbooks}' #{scount}" if DEBUG
+      STDOUT.puts "DEBUG: dir_ext: sorted_cookbooks: '#{sorted_cookbooks}' #{scount}" if Spiceweasel::DEBUG
     end
     if scount > 0
       remainders = unsorted_cookbooks.collect {|x| x['name']}
-      STDOUT.puts "DEBUG: dir_ext: remainders: '#{remainders}'" if DEBUG
-      if NOVALIDATION #stuff is missing, oh well
+      STDOUT.puts "DEBUG: dir_ext: remainders: '#{remainders}'" if Spiceweasel::DEBUG
+      if Spiceweasel::NOVALIDATION #stuff is missing, oh well
         sorted_cookbooks.push(remainders).flatten!
       else
         deps = unsorted_cookbooks.collect {|x| x['dependencies'].collect {|x| x['cookbook']} - sorted_cookbooks}

--- a/lib/spiceweasel/environment_list.rb
+++ b/lib/spiceweasel/environment_list.rb
@@ -25,11 +25,11 @@ class Spiceweasel::EnvironmentList
     if environments
       environments.each do |env|
         environment = env.keys[0]
-        STDOUT.puts "DEBUG: environment: #{environment}" if DEBUG
+        STDOUT.puts "DEBUG: environment: #{environment}" if Spiceweasel::DEBUG
         if File.directory?("environments")
-          validate(environment, cookbooks) unless NOVALIDATION
+          validate(environment, cookbooks) unless Spiceweasel::NOVALIDATION
         else
-          STDERR.puts "'environments' directory not found, unable to validate or load environments" unless NOVALIDATION
+          STDERR.puts "'environments' directory not found, unable to validate or load environments" unless Spiceweasel::NOVALIDATION
         end
         if File.exists?("environments/#{environment}.json")
           @create += "knife environment#{options['knife_options']} from file #{environment}.json\n"
@@ -56,7 +56,7 @@ class Spiceweasel::EnvironmentList
       envcookbooks = File.open("environments/#{environment}.rb").grep(/^cookbook /)
       envcookbooks.each do |cb|
         dep = cb.split()[1].gsub(/"/,'').gsub(/,/,'')
-        STDOUT.puts "DEBUG: environment: '#{environment}' cookbook: '#{dep}'" if DEBUG
+        STDOUT.puts "DEBUG: environment: '#{environment}' cookbook: '#{dep}'" if Spiceweasel::DEBUG
         if !cookbooks.member?(dep)
           STDERR.puts "ERROR: Cookbook dependency '#{dep}' from environment '#{environment}' is missing from the list of cookbooks in the manifest."
           exit(-1)
@@ -67,16 +67,16 @@ class Spiceweasel::EnvironmentList
       f = File.read("environments/#{environment}.json")
       JSON.create_id = nil
       envfile = JSON.parse(f, {:symbolize_names => false})
-      STDOUT.puts "DEBUG: environment: '#{environment}' file: '#{envfile}'" if DEBUG
+      STDOUT.puts "DEBUG: environment: '#{environment}' file: '#{envfile}'" if Spiceweasel::DEBUG
       #validate that the name inside the file matches
-      STDOUT.puts "DEBUG: environment: '#{environment}' name: '#{envfile['name']}'" if DEBUG
+      STDOUT.puts "DEBUG: environment: '#{environment}' name: '#{envfile['name']}'" if Spiceweasel::DEBUG
       if !environment.eql?(envfile['name'])
         STDERR.puts "ERROR: Environment '#{environment}' listed in the manifest does not match the name '#{envfile['name']}' within the 'environments/#{environment}.json' file."
         exit(-1)
       end
       #validate the cookbooks exist if they're mentioned
       envfile['cookbook_versions'].keys.each do |cb|
-        STDOUT.puts "DEBUG: environment: '#{environment}' cookbook: '#{cb}'" if DEBUG
+        STDOUT.puts "DEBUG: environment: '#{environment}' cookbook: '#{cb}'" if Spiceweasel::DEBUG
         if !cookbooks.member?(cb.to_s)
           STDERR.puts "ERROR: Cookbook dependency '#{cb}' from environment '#{environment}' is missing from the list of cookbooks in the manifest."
           exit(-1)

--- a/lib/spiceweasel/node_list.rb
+++ b/lib/spiceweasel/node_list.rb
@@ -4,14 +4,14 @@ class Spiceweasel::NodeList
     if nodes
       nodes.each do |node|
         nname = node.keys[0]
-        STDOUT.puts "DEBUG: node: '#{nname}'" if DEBUG
+        STDOUT.puts "DEBUG: node: '#{nname}'" if Spiceweasel::DEBUG
         #convert spaces to commas, drop multiple commas
         run_list = node[nname][0].gsub(/ /,',').gsub(/,+/,',')
-        STDOUT.puts "DEBUG: node: 'node[nname]' run_list: '#{run_list}'" if DEBUG
-        validateRunList(nname, run_list, cookbooks, roles) unless NOVALIDATION
+        STDOUT.puts "DEBUG: node: 'node[nname]' run_list: '#{run_list}'" if Spiceweasel::DEBUG
+        validateRunList(nname, run_list, cookbooks, roles) unless Spiceweasel::NOVALIDATION
         noptions = node[nname][1]
-        STDOUT.puts "DEBUG: node: 'node[nname]' options: '#{noptions}'" if DEBUG
-        validateOptions(nname, noptions, environments) unless NOVALIDATION
+        STDOUT.puts "DEBUG: node: 'node[nname]' options: '#{noptions}'" if Spiceweasel::DEBUG
+        validateOptions(nname, noptions, environments) unless Spiceweasel::NOVALIDATION
         #provider support
         if nname.start_with?("bluebox ","clodo ","cs ","ec2 ","gandi ","hp ","openstack ","rackspace ","slicehost ","terremark ","voxel ")
           provider = nname.split()
@@ -19,7 +19,7 @@ class Spiceweasel::NodeList
           if (provider.length == 2)
             count = provider[1]
           end
-          if PARALLEL
+          if Spiceweasel::PARALLEL
             @create += "seq #{count} | parallel -j 0 -v \""
             @create += "knife #{provider[0]}#{options['knife_options']} server create #{noptions}"
             if run_list.length > 0

--- a/lib/spiceweasel/role_list.rb
+++ b/lib/spiceweasel/role_list.rb
@@ -25,11 +25,11 @@ class Spiceweasel::RoleList
     if roles
       flatroles = roles.collect {|x| x.keys}.flatten
       flatroles.each do |role|
-        STDOUT.puts "DEBUG: role: #{role}" if DEBUG
+        STDOUT.puts "DEBUG: role: #{role}" if Spiceweasel::DEBUG
         if File.directory?("roles")
-          validate(role, environments, cookbooks, flatroles) unless NOVALIDATION
+          validate(role, environments, cookbooks, flatroles) unless Spiceweasel::NOVALIDATION
         else
-          STDERR.puts "ERROR: 'roles' directory not found, unable to validate or load roles" unless NOVALIDATION
+          STDERR.puts "ERROR: 'roles' directory not found, unable to validate or load roles" unless Spiceweasel::NOVALIDATION
         end
         if File.exists?("roles/#{role}.json")
           @create += "knife role#{options['knife_options']} from file #{role}.json\n"
@@ -48,7 +48,7 @@ class Spiceweasel::RoleList
     if File.exists?("roles/#{role}.rb")
       #validate that the name inside the file matches
       name = File.open("roles/#{role}.rb").grep(/^name/)[0].split()[1].gsub(/"/,'').to_s
-      STDOUT.puts "DEBUG: role: '#{role}' name: '#{name}'" if DEBUG
+      STDOUT.puts "DEBUG: role: '#{role}' name: '#{name}'" if Spiceweasel::DEBUG
       if !role.eql?(name)
         STDERR.puts "ERROR: Role '#{role}' listed in the manifest does not match the name '#{name}' within the roles/#{role}.rb file."
         exit(-1)
@@ -56,12 +56,12 @@ class Spiceweasel::RoleList
       #grab any lines with 'recipe[' or 'role['
       rolerl = File.open("roles/#{role}.rb").grep(/recipe\[|role\[/)
       rolerl.each do |line|
-        STDOUT.puts "DEBUG: role: '#{role}' line: '#{line}'" if DEBUG
+        STDOUT.puts "DEBUG: role: '#{role}' line: '#{line}'" if Spiceweasel::DEBUG
         line.strip.split(',').each do |rl|
           if rl =~ /recipe\[/ #it's a cookbook
             #split on the brackets and any colons
             dep = rl.split(/\[|\]/)[1].split(':')[0]
-            STDOUT.puts "DEBUG: role: '#{role}' cookbook: '#{rl}': dep: '#{dep}'" if DEBUG
+            STDOUT.puts "DEBUG: role: '#{role}' cookbook: '#{rl}': dep: '#{dep}'" if Spiceweasel::DEBUG
             if !cookbooks.member?(dep)
               STDERR.puts "ERROR: Cookbook dependency '#{dep}' from role '#{role}' is missing from the list of cookbooks in the manifest."
               exit(-1)
@@ -69,7 +69,7 @@ class Spiceweasel::RoleList
           elsif rl =~ /role\[/ #it's a role
             #split on the brackets
             dep = rl.split(/\[|\]/)[1]
-            STDOUT.puts "DEBUG: role: '#{role}' role: '#{rl}': dep: '#{dep}'" if DEBUG
+            STDOUT.puts "DEBUG: role: '#{role}' role: '#{rl}': dep: '#{dep}'" if Spiceweasel::DEBUG
             if !roles.member?(dep)
               STDERR.puts "ERROR: Role dependency '#{dep}' from role '#{role}' is missing from the list of roles in the manifest."
               exit(-1)
@@ -84,7 +84,7 @@ class Spiceweasel::RoleList
       JSON.create_id = nil
       rolefile = JSON.parse(f, {:symbolize_names => false})
       #validate that the name inside the file matches
-      STDOUT.puts "DEBUG: role: '#{role}' name: '#{rolefile['name']}'" if DEBUG
+      STDOUT.puts "DEBUG: role: '#{role}' name: '#{rolefile['name']}'" if Spiceweasel::DEBUG
       if !role.eql?(rolefile['name'])
         STDERR.puts "ERROR: Role '#{role}' listed in the manifest does not match the name '#{rolefile['name']}' within the 'roles/#{role}.json' file."
         exit(-1)
@@ -94,7 +94,7 @@ class Spiceweasel::RoleList
         if rl =~ /recipe\[/ #it's a cookbook
           #split on the brackets and any colons
           dep = rl.split(/\[|\]/)[1].split(':')[0]
-          STDOUT.puts "DEBUG: role: '#{role}' cookbook: '#{rl}': dep: '#{dep}'" if DEBUG
+          STDOUT.puts "DEBUG: role: '#{role}' cookbook: '#{rl}': dep: '#{dep}'" if Spiceweasel::DEBUG
           if !cookbooks.member?(dep)
             STDERR.puts "ERROR: Cookbook dependency '#{dep}' from role '#{role}' is missing from the list of cookbooks in the manifest."
             exit(-1)
@@ -102,7 +102,7 @@ class Spiceweasel::RoleList
         elsif rl =~ /role\[/ #it's a role
           #split on the brackets
           dep = rl.split(/\[|\]/)[1]
-          STDOUT.puts "DEBUG: role: '#{role}' role: '#{rl}': dep: '#{dep}'" if DEBUG
+          STDOUT.puts "DEBUG: role: '#{role}' role: '#{rl}': dep: '#{dep}'" if Spiceweasel::DEBUG
           if !roles.member?(dep)
             STDERR.puts "ERROR: Role dependency '#{dep}' from role '#{role}' is missing from the list of roles in the manifest."
             exit(-1)


### PR DESCRIPTION
emopop:chef-repo(master)% spiceweasel infrastructure.yml
/Users/jdewey/.rvm/gems/ruby-1.9.3-p194@chef-repo/gems/spiceweasel-1.1.2/bin/spiceweasel:33: warning: already initialized constant DEBUG

Tracked this down to bundler's no_exec_wrapper.
It defines DEBUG on the global namespace.
  https://github.com/mpapis/rubygems-bundler/blob/master/lib/rubygems-bundler/noexec.rb

Maybe bundler is in the wrong for defining this on the global namespace.  However,
we are doing the same thing in spiceweasel.  Decided to namespace all the constants
under ::Spiceweasel.
