### PR TITLE
Update lib/spiceweasel/cli.rb

### DIFF
--- a/lib/spiceweasel/cli.rb
+++ b/lib/spiceweasel/cli.rb
@@ -197,11 +197,11 @@ module Spiceweasel
       ARGV << "-h" if ARGV.empty?
       begin
         parse_options
-        if Spiceweasel::Config[:knifeconfig]
-          Spiceweasel::Config[:knife_options] = "-c #{Spiceweasel::Config[:knifeconfig]} "
+        if @config[:knifeconfig]
+          Spiceweasel::Config[:knife_options] = " -c #{@config[:knifeconfig]} "
         end
-        if Spiceweasel::Config[:serverurl]
-          Spiceweasel::Config[:knife_options] += "--server-url #{Spiceweasel::Config[:serverurl]} "
+        if @config[:serverurl]
+          Spiceweasel::Config[:knife_options] += "--server-url #{@config[:serverurl]} "
         end
       rescue OptionParser::InvalidOption => e
         STDERR.puts e.message


### PR DESCRIPTION
Fixing respecting the `--knifeconfig` option.

The breakage happens because `Config.merge!(@config)` happens after `parse_options` is called. Thus `Spiceweasel::Config[:knifeconfig]` does not exist yet.
This pull request fixes a spacing issue as well on line 201.
