### PR TITLE
Resolve nil error for berksfile in extract_local

### DIFF
--- a/lib/spiceweasel/extract_local.rb
+++ b/lib/spiceweasel/extract_local.rb
@@ -32,7 +32,8 @@ module Spiceweasel
       end
 
       # COOKBOOKS
-      cookbooks = self.resolve_cookbooks(berksfile.cookbook_list)
+      cookbooks = berksfile ? self.resolve_cookbooks(berksfile.cookbook_list) : self.resolve_cookbooks
+
       objects['cookbooks'] = cookbooks unless cookbooks.empty?
 
       # ROLES


### PR DESCRIPTION
Line 35 originally called `berksfile.cookbook_list` even if `berksfile`
was never instantiated. This commit checks if the berksfile object has
been created before calling `ExtractLocal.resolve_cookbooks` with the
appropriate parameters.
