### PR TITLE
Allow configuration via knife. Use loader for cookbook discovery (#12)

### DIFF
--- a/lib/spiceweasel/extract_local.rb
+++ b/lib/spiceweasel/extract_local.rb
@@ -89,7 +89,7 @@ module Spiceweasel
 
     def self.resolve_cookbooks(berkshelf_cookbooks = {})
       require 'solve'
-      loader = Chef::CookbookLoader.new('./cookbooks')
+      loader = Chef::CookbookLoader.new(Spiceweasel::Config[:cookbook_dir])
       loader.load_cookbooks
       books = loader.cookbooks_by_name
       graph = Solve::Graph.new


### PR DESCRIPTION
Some updates:
- Loads knife configuration values
- Uses cookbook paths defined by chef config or cli passed directories (-C)
- Uses `Loader` to discover cookbooks and pull metadata
- Matches up chef logger to spiceweasel logger
- Spits out stacktrace on error if log level is debug

(Addresses #12)
