### PR TITLE
Add a timeout option for long-running processes, namely knife commands.

### DIFF
--- a/lib/spiceweasel/cli.rb
+++ b/lib/spiceweasel/cli.rb
@@ -130,6 +130,11 @@ module Spiceweasel
     :description => "Use the 'install' command with 'knife cookbook site' instead of the default 'download'",
     :boolean => true
 
+    option :timeout,
+    :short => '-T seconds',
+    :long => '--timeout',
+    :description => "Specify the maximum number of seconds a command is allowed to run without producing output.  Default is 60 seconds"
+
     option :version,
     :short => '-v',
     :long => '--version',
@@ -218,6 +223,9 @@ module Spiceweasel
           Spiceweasel::Config[:knife_options] = " -c #{@config[:knifeconfig]} "
         else
           knife.configure_chef
+        end
+        if @config[:timeout]
+          Spiceweasel::Config[:cmd_timeout] = @config[:timeout].to_i
         end
         if @config[:serverurl]
           Spiceweasel::Config[:knife_options] += "--server-url #{@config[:serverurl]} "

--- a/lib/spiceweasel/config.rb
+++ b/lib/spiceweasel/config.rb
@@ -23,6 +23,9 @@ module Spiceweasel
     extend Mixlib::Config
 
     debug false
+    
+    # child process management
+    cmd_timeout 60
 
     # logging
     log_level :info

--- a/lib/spiceweasel/execute.rb
+++ b/lib/spiceweasel/execute.rb
@@ -25,7 +25,8 @@ module Spiceweasel
     def initialize(commands)
       # for now we're shelling out
       commands.each do | cmd |
-        knife = Mixlib::ShellOut.new(cmd.command, cmd.shellout_opts.merge(:live_stream => STDOUT))
+        Spiceweasel::Log.debug("Command will timeout after #{Spiceweasel::Config[:cmd_timeout]} seconds.")
+        knife = Mixlib::ShellOut.new(cmd.command, cmd.shellout_opts.merge(:live_stream => STDOUT, :timeout => Spiceweasel::Config[:timeout].to_i))
         # check for parallel? and eventually use threads
         knife.run_command
         puts knife.stderr

--- a/lib/spiceweasel/version.rb
+++ b/lib/spiceweasel/version.rb
@@ -17,5 +17,5 @@
 #
 
 module Spiceweasel
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end


### PR DESCRIPTION
I added a --timeout/-T option to allow users to specify their own timeout for command invocations.

This can help if you're doing slow operations and using --parallel which seems to not push back to stdout regularly, which then triggers the timeout.
