### PR TITLE
Fix for Chef 11 when using --knifeconfig

### DIFF
--- a/lib/spiceweasel/cli.rb
+++ b/lib/spiceweasel/cli.rb
@@ -236,8 +236,9 @@ module Spiceweasel
         # Only log on error during startup
         Chef::Config[:verbosity] = 0
         Chef::Config[:log_level] = :error
-        if @config[:knifeconfig]
-          knife.read_config_file(@config[:knifeconfig])
+       if @config[:knifeconfig]
+          fetcher = Chef::ConfigFetcher.new(@config[:knifeconfig], Chef::Config.config_file_jail)
+          knife.read_config(fetcher.read_config, @config[:knifeconfig])
           Spiceweasel::Config[:knife_options] = " -c #{@config[:knifeconfig]} "
         else
           knife.configure_chef


### PR DESCRIPTION
- Fix errors when using -c flag for knife config
- Use config_fetcher ala knife in chef 11 to check config

I'm not sure if chef11 support was in the works, but I hit this error trying to pass a knife.rb using the -c flag. Let me know if you think there is a better way to fix this.
